### PR TITLE
Adds rule to indent case blocks in switch statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
 	globals: { jest: 'readonly' },
 	rules: {
 		'consistent-return': 0,
-		indent: [2, 'tab'],
+		indent: [2, 'tab', { 'SwitchCase': 1 }],
 		'no-tabs': 0,
 		'no-param-reassign': 0,
 		'no-underscore-dangle': 0,


### PR DESCRIPTION
from 

```
switch (navigationState) {
case screenerNavigationState.submitSurvey:
  this.doSubmit();
  break;

```
to 

```
switch (navigationState) {
  case screenerNavigationState.submitSurvey:
    this.doSubmit();
    break;
```